### PR TITLE
Ensure Gemspec is valid

### DIFF
--- a/sfax.gemspec
+++ b/sfax.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['mert@patientbank.com']
   spec.summary       = %q{Wrapper around SFax API}
   spec.description   = %q{Write a longer description. Optional.}
-  spec.homepage      = 'www.patientbank.us'
+  spec.homepage      = 'https://www.patientbank.us/'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")

--- a/sfax.gemspec
+++ b/sfax.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Feridun Mert Celebi']
   spec.email         = ['mert@patientbank.com']
   spec.summary       = %q{Wrapper around SFax API}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
+  spec.description   = %q{Write a longer description. Optional.}
   spec.homepage      = 'www.patientbank.us'
   spec.license       = 'MIT'
 


### PR DESCRIPTION
Bundler has been update so that it no longer will install a gem with an invalid gemspec: https://github.com/bundler/bundler/issues/3895

This PR removes the `TODO`, and fixes the `homepage` `uri` within the Gemspec.